### PR TITLE
fix desktop filename

### DIFF
--- a/com.yktoo.ymuse.yml
+++ b/com.yktoo.ymuse.yml
@@ -38,7 +38,7 @@ modules:
 
       # Copy over the required resources (launcher, icons, localisations)
       - mkdir -p /app/share/icons /app/share/locale
-      - install -Dm644 resources/ymuse.desktop -t /app/share/applications/
+      - install -Dm644 resources/com.yktoo.ymuse.desktop -t /app/share/applications/
       - install -Dm644 resources/metainfo/com.yktoo.ymuse.appdata.xml -t /app/share/metainfo/
       - cp -r resources/i18n/generated/* /app/share/locale/
       - cp -r resources/icons/hicolor    /app/share/icons/


### PR DESCRIPTION
Flathub build of v0.21 is failing due to a change of the ymuse.desktop filename:
https://buildbot.flathub.org/#/builders/11/builds/8263
This PR should fix it