### PR TITLE
Upgrade Freedesktop runtime to 24.08

### DIFF
--- a/com.yktoo.ymuse.appdata.xml
+++ b/com.yktoo.ymuse.appdata.xml
@@ -9,7 +9,10 @@
     <p>Ymuse is an easy, functional, and snappy GTK front-end (client) for Music Player Daemon written in Go.</p>
   </description>
   <screenshots>
-    <screenshot type="default">https://res.cloudinary.com/yktoo/image/upload/blog/e6ecokfftenpwlwswon1.png</screenshot>
+    <screenshot width="1139" height="763" type="default">
+      <image>https://res.cloudinary.com/yktoo/image/upload/blog/e6ecokfftenpwlwswon1.png</image>
+      <caption>Ymuse main window (Queue tab).</caption>
+    </screenshot>
   </screenshots>
   <url type="homepage">https://yktoo.com/en/software/ymuse/</url>
   <url type="bugtracker">https://github.com/yktoo/ymuse/issues</url>

--- a/com.yktoo.ymuse.appdata.xml
+++ b/com.yktoo.ymuse.appdata.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>com.yktoo.ymuse</id>
+  <launchable type="desktop-id">com.yktoo.ymuse.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>Apache-2.0</project_license>
   <name>Ymuse</name>

--- a/com.yktoo.ymuse.yml
+++ b/com.yktoo.ymuse.yml
@@ -1,6 +1,6 @@
 app-id: com.yktoo.ymuse
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang


### PR DESCRIPTION
works for me

Also fixes two issues reported by the flatpak linter:
-  `"E: com.yktoo.ymuse:~: desktop-app-launchable-missing",`
-  `"E: com.yktoo.ymuse:12: screenshot-no-media"`